### PR TITLE
Change to material icon

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -26,7 +26,7 @@
         "localLink": "%protocol%://%ip%:%port%",
         "adminTab": {
             "link": "%protocol%://%ip%:%port%",
-            "fa-icon": "fa-terminal"
+            "fa-icon": "subtitles"
         },
         "authors": [
             {


### PR DESCRIPTION
Remnants of the FontAwesome have been eliminated. Added materialize icons for tab.